### PR TITLE
Fixed ForbiddenFunctionSniff

### DIFF
--- a/Sniffs/Security/ForbiddenFunctionSniff.php
+++ b/Sniffs/Security/ForbiddenFunctionSniff.php
@@ -4,7 +4,7 @@ class Ecg_Sniffs_Security_ForbiddenFunctionSniff extends Generic_Sniffs_PHP_Forb
 {
     protected $patternMatch = true;
 
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
         '^assert$' => null,
         '^bind_textdomain_codeset$' => null,
         '^bindtextdomain$' => null,


### PR DESCRIPTION
Access level on Ecg_Sniffs_Security_ForbiddenFunctionSniff for current PHPCS versions.

Fixes #9

This little patch was missing and not yet offered so far.