### PR TITLE
Fix infinity loop in include sniff

### DIFF
--- a/Sniffs/Security/IncludeFileSniff.php
+++ b/Sniffs/Security/IncludeFileSniff.php
@@ -34,7 +34,8 @@ class Ecg_Sniffs_Security_IncludeFileSniff implements PHP_CodeSniffer_Sniff
         $hasVariable      = false;
         $includePath      = '';
 
-        while($tokens[$nextToken]['code'] !== T_SEMICOLON) {
+        while($tokens[$nextToken]['code'] !== T_SEMICOLON &&
+            $tokens[$nextToken]['code'] !== T_CLOSE_TAG) {
             switch ($tokens[$nextToken]['code']) {
                 case T_CONSTANT_ENCAPSED_STRING :
                     $includePath = trim($tokens[$nextToken]['content'], '"\'');


### PR DESCRIPTION
"while" loop keeps checking for semicolon as next token. It leads to infinity loop if there is include call inside PHP tags without semicolon at the end eg.:

    <?php include $this->something() ?>