### PR TITLE
Allow PHTML files to be scanned from app/design

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -19,7 +19,9 @@
     <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.Metrics.CyclomaticComplexity"/>
     <rule ref="Generic.Metrics.NestingLevel"/>
-    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
+    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag">
+        <exclude-pattern>*.phtml</exclude-pattern>
+    </rule>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
     <rule ref="Squiz.Functions.GlobalFunction"/>
@@ -29,10 +31,10 @@
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.NonExecutableCode"/>
 
-    <rule ref="Zend.Files.ClosingTag"/>
-
+    <rule ref="Zend.Files.ClosingTag">
+        <exclude-pattern>*.phtml</exclude-pattern>
+    </rule>
     <rule ref="Ecg.Security.LanguageConstruct.DirectOutput">
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
-
 </ruleset>


### PR DESCRIPTION
And suppress phtml-file compatible warnings such as no closing PHP tag, direct output, chars before PHP open tag