### PR TITLE
Moved pathinfo to discouraged functions list

### DIFF
--- a/Sniffs/Security/DiscouragedFunctions.php
+++ b/Sniffs/Security/DiscouragedFunctions.php
@@ -1,0 +1,30 @@
+<?php
+
+class Ecg_Sniffs_Security_DiscouragedFunctionSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
+{
+    /**
+     * If true, an error will be thrown; otherwise a warning.
+     *
+     * @var bool
+     */
+    public $error = false;
+
+    /**
+     * If true, forbidden functions will be considered regular expressions.
+     *
+     * @var bool
+     */
+    protected $patternMatch = true;
+
+    /**
+     * A list of forbidden functions with their alternatives.
+     *
+     * The value is NULL if no alternative exists. IE, the
+     * function should just not be used.
+     *
+     * @var array(string => string|null)
+     */
+    public $forbiddenFunctions = array(
+        '^pathinfo$' => null,
+    );
+}

--- a/Sniffs/Security/ForbiddenFunctionSniff.php
+++ b/Sniffs/Security/ForbiddenFunctionSniff.php
@@ -173,7 +173,6 @@ class Ecg_Sniffs_Security_ForbiddenFunctionSniff extends Generic_Sniffs_PHP_Forb
         '^var_dump$' => null,
         '^tempnam$' => null,
         '^realpath$' => null,
-        '^pathinfo$' => null,
         '^linkinfo$' => null,
         '^lstat$' => null,
         '^stat$' => null,


### PR DESCRIPTION
I really don't agree with pathinfo being on the list of forbidden functions. It's so useful and I don't know of any alternative in the Zend_Core (correct me if I'm in the wrong here).

So, I've created a new class that warns about the usage of this function instead of spitting out an error. Another solution would be to create a custom ruleset.xml file. I'm new to PHP-CS, so I would be glad if you could shine some light on which way would be the most appropriate.