### PR TITLE
Removed PrivateClassMember Sniff from ruleset for M2

### DIFF
--- a/EcgM2/ruleset.xml
+++ b/EcgM2/ruleset.xml
@@ -45,7 +45,6 @@
     <rule ref="Ecg.Performance.Loop"/>
     <rule ref="Ecg.PHP.Goto"/>
     <rule ref="Ecg.PHP.Namespace"/>
-    <rule ref="Ecg.PHP.PrivateClassMember"/>
     <rule ref="Ecg.PHP.Var"/>
     <rule ref="Ecg.Security.ForbiddenFunction"/>
     <rule ref="Ecg.Security.IncludeFile"/>


### PR DESCRIPTION
M2 best practice recommends using private class members instead of protected.