### PR TITLE
forbiddenFunctions visibility

### DIFF
--- a/Sniffs/Security/ForbiddenFunctionSniff.php
+++ b/Sniffs/Security/ForbiddenFunctionSniff.php
@@ -4,7 +4,7 @@ class Ecg_Sniffs_Security_ForbiddenFunctionSniff extends Generic_Sniffs_PHP_Forb
 {
     protected $patternMatch = true;
 
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
         '^assert$' => null,
         '^bind_textdomain_codeset$' => null,
         '^bindtextdomain$' => null,


### PR DESCRIPTION
Fatal error: Access level to Ecg_Sniffs_Security_ForbiddenFunctionSniff::$forbiddenFunctions must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff)

https://github.com/squizlabs/PHP_CodeSniffer/issues/263