### PR TITLE
Add relative rule reference to ECG ruleset (fixes #39, #37)

### DIFF
--- a/EcgM2/ruleset.xml
+++ b/EcgM2/ruleset.xml
@@ -2,6 +2,7 @@
 <ruleset name="EcgM2">
     <description>Magento 2 ECG Coding Standard</description>
 
+    <rule ref="../Ecg"/>
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>


### PR DESCRIPTION
Composer installs in Magento 2 sites can't run the ECGM2 ruleset. This is documented in #37, #39. This PR fixes this problem with a relative path to include the sniffs for ECG ruleset.