### PR TITLE
Allow private class members (M2)

### DIFF
--- a/EcgM2/ruleset.xml
+++ b/EcgM2/ruleset.xml
@@ -62,4 +62,8 @@
     <rule ref="EcgM2.Templates.ThisInTemplate">
         <exclude-pattern>*.php</exclude-pattern>
     </rule>
+
+    <rule ref="Ecg.PHP.PrivateClassMember">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
 </ruleset>


### PR DESCRIPTION
PR #40 imported all Magento 1 rules, which rendered  #34 useless. To overcome this, we explicitly exclude the rule for all files now.