### PR TITLE
Add Composer package type

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ $ phpcs --standard=./vendor/magento-ecg/coding-standard/Ecg /path/to/code
 $ phpcs --standard=./vendor/magento-ecg/coding-standard/EcgM2 /path/to/code
 ```
 
-As a one time thing, you can add the ECG standards directory to PHP_CodeSniffer's installed paths:
+This package is compatible with Composer Installer Plugins for PHPCS coding standards (such as https://github.com/Dealerdirect/phpcodesniffer-composer-installer) and can be automatically registered with PHPCS during installation.
+
+Alternatively, you can manually add the ECG standards directory to PHP_CodeSniffer's installed paths:
 ```sh
 $ phpcs --config-set installed_paths /path/to/your/folder/vendor/magento-ecg/coding-standard
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "A set of PHP_CodeSniffer rules and sniffs.",
     "homepage": "https://github.com/magento-ecg/coding-standard",
     "license": "MIT",
+    "type": "phpcodesniffer-standard",
     "authors": [
         {
             "name": "Magento Expert Consulting Group",


### PR DESCRIPTION
Add package type to `composer.json` to allow the package to be automatically registered with PHPCS.

Please refer to https://github.com/Dealerdirect/phpcodesniffer-composer-installer/wiki/Change-%60composer.json%60-%22type%22-to-%60phpcodesniffer-standard%60 for more information.