### PR TITLE
Fixed undefined array key "parenthesis_opener"

### DIFF
--- a/Ecg/Sniffs/Performance/LoopSniff.php
+++ b/Ecg/Sniffs/Performance/LoopSniff.php
@@ -70,7 +70,7 @@ class LoopSniff implements Sniff
             return;
         }
 
-        for ($ptr = $tokens[$stackPtr]['parenthesis_opener'] + 1; $ptr < $tokens[$stackPtr]['scope_closer']; $ptr++) {
+        for ($ptr = ($tokens[$stackPtr]['parenthesis_opener'] ?? 0) + 1; $ptr < $tokens[$stackPtr]['scope_closer']; $ptr++) {
             $content = $tokens[$ptr]['content'];
             if ($tokens[$ptr]['code'] !== T_STRING || in_array($ptr, $this->processedStackPointers)) {
                 continue;


### PR DESCRIPTION
Running phpcs on openmage generates:

```
FILE: /Users/fab/Projects/openmage/lib/Varien/Filter/Template/Tokenizer/Variable.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: Undefined array key "parenthesis_opener" in
   |       | /Users/fab/Projects/openmage/vendor/magento-ecg/coding-standard/Ecg/Sniffs/Performance/LoopSniff.php on line 73
   |       | The error originated in the Ecg.Performance.Loop sniff on line 73. (Internal.Exception)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

(it actually generates many of the same error lines).

This PR fixes it.

Fixes https://github.com/magento-ecg/coding-standard/issues/70