### PR TITLE
fix when omitting variable in catch clause

### DIFF
--- a/Ecg/Sniffs/PHP/NamespaceSniff.php
+++ b/Ecg/Sniffs/PHP/NamespaceSniff.php
@@ -38,7 +38,7 @@ class NamespaceSniff implements Sniff
 
         $endOfTryStatement = $phpcsFile->findEndOfStatement($stackPtr);
         $posOfCatchVariable = $phpcsFile->findNext(T_VARIABLE, $stackPtr, $endOfTryStatement);
-        $posOfExceptionClassName = $phpcsFile->findNext(T_STRING, $stackPtr, $posOfCatchVariable);
+        $posOfExceptionClassName = $phpcsFile->findNext(T_STRING, $stackPtr, $posOfCatchVariable ?: $endOfTryStatement);
         $posOfNsSeparator = $phpcsFile->findNext(T_NS_SEPARATOR, $stackPtr, $posOfExceptionClassName);
 
         if ($posOfNsSeparator === false) {


### PR DESCRIPTION
Using the following construct:

```php
try {
} catch (\My\Namespace\MyException) {
}
```

Results in:

```
1 | ERROR | Namespace for "<?php" class is not specified.
```

This PR fixes this so both scenarios with a variable or without variable in the catch clause will work.